### PR TITLE
更新 HowToCook 的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 文字超大段copy自[《老乡鸡菜品溯源报告》](https://www.lxjchina.com.cn/display.asp?id=4226)，有编辑与整理
 
-指路隔壁 [How To Cook](https://cook.aiurs.co/)
+指路隔壁 [How To Cook](https://cook.aiursoft.cn/)
 
 至于为什么仓库名要叫CookLikeHOC，因为直接写Laoxiangji大概不方便阅读，而Home Original Chicken是china daily报道中所使用的老乡鸡的英文名，故简写成HOC。
 


### PR DESCRIPTION
老的域名已经不再维护。新的域名 cook.aiursoft.cn