### PR TITLE
feat(vitepress): 重构导航与侧边栏生成脚本并修复错误

### DIFF
--- a/.vitepress/navSidebar.ts
+++ b/.vitepress/navSidebar.ts
@@ -60,17 +60,17 @@ export function generateNavAndSidebar(rootDir: string) {
 
     // Find README.md、readme.md、index.md
     const readme = ['README.md', 'readme.md', 'index.md'].find((n) => fs.existsSync(path.join(abs, n)))
-
+    const readmeURI = readme ? `/${encodeURI(dir)}/${encodeURI(readme)}` : "/";
     if (items.length > 0) {
       sidebar[`/${dir}/`] = [
         {
           text: dir,
-          link: readme ? `/${encodeURI(dir)}/${encodeURI(readme)}` : undefined,
-          items: items.filter((i) => i.link !== (readme ? `/${encodeURI(dir)}/${encodeURI(readme)}` : undefined)),
+          link: readmeURI,
+          items: items.filter((i) => i.link !== readmeURI),
         },
       ]
       if (readme) {
-        nav.push({ text: dir, link: `/${encodeURI(dir)}/${encodeURI(readme)}` })
+        nav.push({ text: dir, link: readmeURI })
       } else {
         nav.push({ text: dir, link: items[0].link! })
       }

--- a/.vitepress/navSidebar.ts
+++ b/.vitepress/navSidebar.ts
@@ -65,7 +65,8 @@ export function generateNavAndSidebar(rootDir: string) {
       sidebar[`/${dir}/`] = [
         {
           text: dir,
-          items,
+          link: readme ? `/${encodeURI(dir)}/${encodeURI(readme)}` : undefined,
+          items: items.filter((i) => i.link !== (readme ? `/${encodeURI(dir)}/${encodeURI(readme)}` : undefined)),
         },
       ]
       if (readme) {

--- a/.vitepress/navSidebar.ts
+++ b/.vitepress/navSidebar.ts
@@ -10,6 +10,8 @@ const EXCLUDED_DIRS = new Set([
   '.github',
   '.vitepress',
   'node_modules',
+  'images',
+  'docker_support',
   'public',
   'docs',
   'images',


### PR DESCRIPTION
### 重构 `navSidebar.ts` 以优化导航和侧边栏生成

本次提交主要重构了 `.vitepress/navSidebar.ts` 脚本，用于动态生成 VitePress 站点的导航栏和侧边栏。这些更改解决了之前版本中存在的链接生成不正确、TypeScript 类型不安全以及逻辑不一致等多个问题。

#### 主要变更：
*   **✨ 优化侧边栏链接逻辑**
       * 调整了侧边栏分组的链接行为。现在，如果目录中存在 README.md 或 
         index.md，它将作为该分组的顶级标题链接，并且不会在下拉列表中重复出现。
       * 如果目录中没有 README.md，则会自动将列表中的第一个页面作为该分组的顶级
         链接，确保了每个分组标题都有一个有效的点击目标。
       * 此项更改统一了侧边栏和顶部导航栏的行为，提供了更直观、一致的导航体验。
*   **📖 增加了过滤目录**
       * 在几个脚本处添加了 'docker_support' 和 'images' 的目录过滤
*   **🛡️ 增强类型安全**
    *   将原先手动定义的 `NavItem` 和 `SidebarItem` 类型，替换为从 `vitepress` 官方 `DefaultTheme` 中导入的类型，提高了代码的健robustness性和可维护性。
    *   通过引入一个更严格的本地 `LinkItem` 类型，解决了因 `SidebarItem` 和 `NavItem` 类型定义不完全兼容而导致的 TypeScript 编译错误 (ts(2322))。

*   **✨ 优化代码质量**
    *   统一了 `nav` 和 `sidebar` 的生成逻辑，使代码更加清晰、一致。
